### PR TITLE
fix: update CI workflow branch references from main to master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main, develop, beta, alpha ]
+    branches: [ master, develop, beta, alpha ]
   pull_request:
-    branches: [ main, develop ]
+    branches: [ master, develop ]
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
## Summary
- Updated CI workflow to use `master` branch instead of `main`
- Fixed pull request triggers not working due to branch name mismatch

## Test plan
- [x] Verify this PR triggers CI status checks
- [x] Check that all CI jobs run successfully
- [x] Confirm status checks appear in PR

🤖 Generated with [Claude Code](https://claude.ai/code)