### PR TITLE
refactor: rename project from mac-daemon-control to daemon-control

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,7 +26,7 @@ linters:
   # - `fast`: enables only linters considered as "fast".
   # Default: standard
   default: none
-  
+
   # Enable specific linters.
   enable:
     - bodyclose
@@ -34,7 +34,7 @@ linters:
     - dupl
     - errcheck
     - exhaustive
-    - copyloopvar  # replaces exportloopref in newer versions
+    - copyloopvar # replaces exportloopref in newer versions
     - funlen
     - gochecknoinits
     - goconst
@@ -105,67 +105,67 @@ linters:
       - path: cmd/
         linters:
           - gochecknoinits
-      
+
       # Exclude gochecknoinits from utils (required for initialization)
       - path: internal/utils/utils.go
         linters:
           - gochecknoinits
-      
+
       # Exclude high cyclomatic complexity for complex functions
       - path: cmd/generate.go
         linters:
           - gocyclo
-      
+
       - path: internal/config/loader.go
         linters:
           - gocyclo
-      
+
       - path: internal/plist/generator.go
         linters:
           - gocyclo
-      
+
       # Exclude gosec subprocess warnings for legitimate use cases
       - path: cmd/edit.go
         linters:
           - gosec
         text: "G204:"
-      
+
       - path: cmd/tail.go
         linters:
           - gosec
         text: "G204:"
-      
+
       # Exclude gosec file inclusion warnings for config/plist operations
       - path: cmd/generate.go
         linters:
           - gosec
         text: "G304:"
-      
+
       - path: internal/utils/utils.go
         linters:
           - gosec
         text: "G304:"
-      
+
       # Exclude line length warnings for struct tags
       - path: internal/config/schema.go
         linters:
           - lll
-      
+
       # Exclude some linters from test files
       - path: _test\.go
         linters:
           - funlen
           - dupl
-      
+
       # Exclude funlen for complex but necessary functions
       - path: cmd/generate.go
         linters:
           - funlen
-      
+
       - path: internal/plist/generator.go
         linters:
           - funlen
-      
+
       # Exclude gosec file path warnings for logs command (legitimate use)
       - path: cmd/logs.go
         linters:
@@ -178,7 +178,7 @@ formatters:
   enable:
     - gofmt
     - goimports
-  
+
   # Formatters settings.
   settings:
     goimports:
@@ -186,14 +186,14 @@ formatters:
       # with the given prefixes are grouped after 3rd-party packages.
       # Default: []
       local-prefixes:
-        - github.com/mjmorales/mac-daemon-control
+        - github.com/mjmorales/daemon-control
 
 # Issues configuration.
 issues:
   # Maximum issues count per one linter.
   # Default: 50
   max-issues-per-linter: 0
-  
+
   # Maximum count of issues with the same text.
   # Default: 3
   max-same-issues: 0

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -116,7 +116,7 @@ changelog:
 release:
   github:
     owner: mjmorales
-    name: mac-daemon-control
+    name: daemon-control
   draft: false
   prerelease: auto
   name_template: "{{.ProjectName}} v{{.Version}}"
@@ -129,13 +129,13 @@ brews:
       name: homebrew-tap
       branch: main
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
-    url_template: "https://github.com/mjmorales/mac-daemon-control/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+    url_template: "https://github.com/mjmorales/daemon-control/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
     download_strategy: CurlDownloadStrategy
     commit_author:
       name: goreleaserbot
       email: goreleaser@mjmorales.com
     commit_msg_template: "Brew formula update for {{ .ProjectName }} version {{ .Tag }}"
-    homepage: "https://github.com/mjmorales/mac-daemon-control"
+    homepage: "https://github.com/mjmorales/daemon-control"
     description: "A generic daemon control tool for managing macOS LaunchAgent daemons"
     license: "MIT"
     skip_upload: auto
@@ -143,7 +143,6 @@ brews:
       system "#{bin}/daemon-control", "--help"
     install: |
       bin.install "daemon-control"
-
 
 # SBOM generation
 sboms:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ golangci-lint run
 # Format code
 make fmt
 gofmt -w .
-goimports -local github.com/mjmorales/mac-daemon-control -w .
+goimports -local github.com/mjmorales/daemon-control -w .
 
 # Run go vet
 make vet
@@ -119,7 +119,7 @@ make deps-verify
 - The project uses golangci-lint v2.3.0 with custom exclusion rules in `.golangci.yml`
 - GoReleaser v2 configuration format
 - Repository URL: `https://github.com/mjmorales/daemon-control.git`
-- Package import path: `github.com/mjmorales/mac-daemon-control`
+- Package import path: `github.com/mjmorales/daemon-control`
 
 ## Testing Daemon Operations
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # daemon-control
 
-[![CI](https://github.com/mjmorales/mac-daemon-control/actions/workflows/ci.yml/badge.svg)](https://github.com/mjmorales/mac-daemon-control/actions/workflows/ci.yml)
-[![Release](https://github.com/mjmorales/mac-daemon-control/actions/workflows/release.yml/badge.svg)](https://github.com/mjmorales/mac-daemon-control/actions/workflows/release.yml)
-[![Go Report Card](https://goreportcard.com/badge/github.com/mjmorales/mac-daemon-control)](https://goreportcard.com/report/github.com/mjmorales/mac-daemon-control)
-[![codecov](https://codecov.io/gh/mjmorales/mac-daemon-control/branch/main/graph/badge.svg)](https://codecov.io/gh/mjmorales/mac-daemon-control)
+[![CI](https://github.com/mjmorales/daemon-control/actions/workflows/ci.yml/badge.svg)](https://github.com/mjmorales/daemon-control/actions/workflows/ci.yml)
+[![Release](https://github.com/mjmorales/daemon-control/actions/workflows/release.yml/badge.svg)](https://github.com/mjmorales/daemon-control/actions/workflows/release.yml)
+[![Go Report Card](https://goreportcard.com/badge/github.com/mjmorales/daemon-control)](https://goreportcard.com/report/github.com/mjmorales/daemon-control)
+[![codecov](https://codecov.io/gh/mjmorales/daemon-control/branch/main/graph/badge.svg)](https://codecov.io/gh/mjmorales/daemon-control)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Go Version](https://img.shields.io/github/go-mod/go-version/mjmorales/mac-daemon-control)](https://go.dev/)
-[![Latest Release](https://img.shields.io/github/release/mjmorales/mac-daemon-control.svg)](https://github.com/mjmorales/mac-daemon-control/releases/latest)
+[![Go Version](https://img.shields.io/github/go-mod/go-version/mjmorales/daemon-control)](https://go.dev/)
+[![Latest Release](https://img.shields.io/github/release/mjmorales/daemon-control.svg)](https://github.com/mjmorales/daemon-control/releases/latest)
 
 A powerful and generic daemon control tool for managing macOS LaunchAgent daemons. Simplify the creation, installation, and management of background services on macOS.
 
@@ -25,19 +25,19 @@ A powerful and generic daemon control tool for managing macOS LaunchAgent daemon
 
 ### Download Pre-built Binary
 
-Download the latest release from the [releases page](https://github.com/mjmorales/mac-daemon-control/releases).
+Download the latest release from the [releases page](https://github.com/mjmorales/daemon-control/releases).
 
 ```bash
 # Download and extract (example for macOS arm64)
-curl -L https://github.com/mjmorales/mac-daemon-control/releases/latest/download/daemon-control_Darwin_arm64.tar.gz | tar xz
+curl -L https://github.com/mjmorales/daemon-control/releases/latest/download/daemon-control_Darwin_arm64.tar.gz | tar xz
 sudo mv daemon-control /usr/local/bin/
 ```
 
 ### Build from Source
 
 ```bash
-git clone https://github.com/mjmorales/mac-daemon-control.git
-cd mac-daemon-control
+git clone https://github.com/mjmorales/daemon-control.git
+cd daemon-control
 make build
 sudo make install
 ```
@@ -203,6 +203,6 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## 📮 Support
 
-- Report bugs via [GitHub Issues](https://github.com/mjmorales/mac-daemon-control/issues)
-- Request features via [GitHub Issues](https://github.com/mjmorales/mac-daemon-control/issues)
-- Ask questions in [GitHub Discussions](https://github.com/mjmorales/mac-daemon-control/discussions)
+- Report bugs via [GitHub Issues](https://github.com/mjmorales/daemon-control/issues)
+- Request features via [GitHub Issues](https://github.com/mjmorales/daemon-control/issues)
+- Ask questions in [GitHub Discussions](https://github.com/mjmorales/daemon-control/discussions)

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 
-	"github.com/mjmorales/mac-daemon-control/internal/core"
+	"github.com/mjmorales/daemon-control/internal/core"
 )
 
 // configCmd represents the config command

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -11,7 +11,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 
-	"github.com/mjmorales/mac-daemon-control/internal/core"
+	"github.com/mjmorales/daemon-control/internal/core"
 )
 
 var (

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -7,10 +7,10 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 
-	"github.com/mjmorales/mac-daemon-control/internal/config"
-	"github.com/mjmorales/mac-daemon-control/internal/core"
-	"github.com/mjmorales/mac-daemon-control/internal/plist"
-	"github.com/mjmorales/mac-daemon-control/internal/utils"
+	"github.com/mjmorales/daemon-control/internal/config"
+	"github.com/mjmorales/daemon-control/internal/core"
+	"github.com/mjmorales/daemon-control/internal/plist"
+	"github.com/mjmorales/daemon-control/internal/utils"
 )
 
 var (

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -7,7 +7,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 
-	"github.com/mjmorales/mac-daemon-control/internal/utils"
+	"github.com/mjmorales/daemon-control/internal/utils"
 )
 
 // installCmd represents the install command

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -9,7 +9,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 
-	"github.com/mjmorales/mac-daemon-control/internal/utils"
+	"github.com/mjmorales/daemon-control/internal/utils"
 )
 
 // listCmd represents the list command

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -8,7 +8,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 
-	"github.com/mjmorales/mac-daemon-control/internal/utils"
+	"github.com/mjmorales/daemon-control/internal/utils"
 )
 
 // logsCmd represents the logs command

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -8,7 +8,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 
-	"github.com/mjmorales/mac-daemon-control/internal/utils"
+	"github.com/mjmorales/daemon-control/internal/utils"
 )
 
 // startCmd represents the start command

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -9,7 +9,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 
-	"github.com/mjmorales/mac-daemon-control/internal/utils"
+	"github.com/mjmorales/daemon-control/internal/utils"
 )
 
 // statusCmd represents the status command

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -6,7 +6,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 
-	"github.com/mjmorales/mac-daemon-control/internal/utils"
+	"github.com/mjmorales/daemon-control/internal/utils"
 )
 
 // stopCmd represents the stop command

--- a/cmd/tail.go
+++ b/cmd/tail.go
@@ -8,7 +8,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 
-	"github.com/mjmorales/mac-daemon-control/internal/utils"
+	"github.com/mjmorales/daemon-control/internal/utils"
 )
 
 // tailCmd represents the tail command

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -7,7 +7,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 
-	"github.com/mjmorales/mac-daemon-control/internal/utils"
+	"github.com/mjmorales/daemon-control/internal/utils"
 )
 
 // uninstallCmd represents the uninstall command

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mjmorales/mac-daemon-control
+module github.com/mjmorales/daemon-control
 
 go 1.24.1
 

--- a/internal/plist/generator.go
+++ b/internal/plist/generator.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/rs/zerolog/log"
 
-	"github.com/mjmorales/mac-daemon-control/internal/config"
+	"github.com/mjmorales/daemon-control/internal/config"
 )
 
 // Generator creates plist files from daemon configurations

--- a/internal/plist/generator_test.go
+++ b/internal/plist/generator_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/mjmorales/mac-daemon-control/internal/config"
+	"github.com/mjmorales/daemon-control/internal/config"
 )
 
 func TestNewGenerator(t *testing.T) {

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/rs/zerolog/log"
 
-	"github.com/mjmorales/mac-daemon-control/internal/core"
+	"github.com/mjmorales/daemon-control/internal/core"
 )
 
 // GetDaemonsDir returns the daemons directory from config

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/mjmorales/mac-daemon-control/cmd"
+import "github.com/mjmorales/daemon-control/cmd"
 
 func main() {
 	cmd.Execute()


### PR DESCRIPTION
- Update module paths and import statements across the codebase to reflect the new project name.
- Modify configuration files, README, and documentation to ensure consistency with the new name.
- Adjust CI/CD workflows and badges to point to the updated repository.

🤖 Generated with [Claude Code](https://claude.ai/code)