### PR TITLE
fix: add syft installation to release workflow for SBOM generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,10 @@ jobs:
             echo "new_release=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Install Syft
+        if: steps.semantic.outputs.new_release == 'true'
+        uses: anchore/sbom-action/download-syft@v0
+
       - name: Run GoReleaser
         if: steps.semantic.outputs.new_release == 'true'
         uses: goreleaser/goreleaser-action@v6


### PR DESCRIPTION
## Summary
- Fixes GoReleaser error: "syft: executable file not found in $PATH" during release workflow
- Adds syft installation step before GoReleaser runs to enable SBOM generation
- Uses official anchore/sbom-action/download-syft@v0 GitHub Action

## Test plan
- [x] Verify syft installation step is added to release.yml
- [x] Confirm it only runs when a new release is created (matching GoReleaser condition)
- [ ] Next release will validate that SBOM artifacts are generated successfully

🤖 Generated with [Claude Code](https://claude.ai/code)