### PR TITLE
fix: add GPG key import step to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,23 @@ jobs:
         if: steps.semantic.outputs.new_release == 'true'
         uses: anchore/sbom-action/download-syft@v0
 
+      - name: Import GPG key
+        if: steps.semantic.outputs.new_release == 'true' && env.GPG_PRIVATE_KEY != '' && env.GPG_FINGERPRINT != ''
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_FINGERPRINT: ${{ secrets.GPG_FINGERPRINT }}
+        run: |
+          echo "Importing GPG key..."
+          echo "$GPG_PRIVATE_KEY" | gpg --batch --import
+          
+          # Verify the key was imported and matches the expected fingerprint
+          gpg --list-secret-keys --keyid-format=long | grep -q "$GPG_FINGERPRINT" || {
+            echo "Error: Imported key fingerprint does not match expected fingerprint"
+            exit 1
+          }
+          
+          echo "GPG key imported successfully"
+
       - name: Run GoReleaser
         if: steps.semantic.outputs.new_release == 'true'
         uses: goreleaser/goreleaser-action@v6


### PR DESCRIPTION
## Summary
- Fixes GoReleaser GPG signing error: "Invalid user ID" during release workflow
- Adds GPG key import step that imports the private key and verifies the fingerprint
- Uses both `secrets.GPG_PRIVATE_KEY` and `secrets.GPG_FINGERPRINT` for secure signing

## Implementation Details
- Import GPG private key before GoReleaser runs
- Verify imported key fingerprint matches expected fingerprint for security
- Only runs when both secrets are available to prevent failures

## Test plan
- [x] Verify GPG import step is added to release.yml
- [x] Confirm it only runs when a new release is created
- [x] Validate fingerprint verification is in place
- [ ] Next release will validate that artifact signing works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)